### PR TITLE
Updated docker-compose.yml for docker-sonarqube

### DIFF
--- a/recipes/docker-compose-postgres-example.yml
+++ b/recipes/docker-compose-postgres-example.yml
@@ -16,6 +16,8 @@ services:
 
   db:
     image: postgres
+    ports:
+      - "5432:5432"
     networks:
       - sonarnet
     environment:


### PR DESCRIPTION
Exposed db container port ( 5432 ) on the host port, Through which you can connect to your db container.
ports:
    - "5432:5432"